### PR TITLE
Switch to I2S parallel LED driver

### DIFF
--- a/klausuhr_esp/klausuhr_esp.ino
+++ b/klausuhr_esp/klausuhr_esp.ino
@@ -352,6 +352,7 @@ void drawBonusBottom(time_t now) {
 void setup() {
   Serial.begin(115200);
   delay(200);                       // Stabilisierung nach Reset
+  Serial.println(F("Setup gestartet"));
 
   // 1) Erzeuge und aktiviere den Lock, der Light-Sleep komplett verhindert | Fehlerbehebung: WLAN-Disconnection bei Aufruf von Website
   esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "no_light_sleep", &pm_lock_l0);
@@ -359,6 +360,11 @@ void setup() {
   
   // 2) LED‑Streifen initialisieren
   leds = (CRGB*)heap_caps_malloc(NUM_STRIPS * PIXELS_PER_STRIP * sizeof(CRGB), MALLOC_CAP_DMA);
+  if (!leds) {
+    Serial.println(F("LED-Puffer konnte nicht reserviert werden"));
+  } else {
+    Serial.printf("LED-Puffer: %p\n", leds);
+  }
   int idx = 0;
   for (int i = 0; i < 5; ++i) { timerLeds[i] = &leds[idx]; idx += PIXELS_PER_STRIP; }
   for (int i = 0; i < 5; ++i) { nachLeds[i]  = &leds[idx]; idx += PIXELS_PER_STRIP; }
@@ -371,6 +377,7 @@ void setup() {
   memcpy(dataPins, tmp, sizeof(dataPins));
   ledDriver.initled((uint8_t*)leds, dataPins, NUM_STRIPS, PIXELS_PER_STRIP,
                     static_cast<colorarrangment>(ORDER_GRB));
+  Serial.println(F("LED-Treiber initialisiert"));
   clearAll();
   ledDriver.showPixels();
 
@@ -379,6 +386,7 @@ void setup() {
     Serial.println(F("LittleFS Mount failed – stopping."));
     while (true) delay(200);
   }
+  Serial.println(F("LittleFS bereit"));
 
   // 4) WLAN Setup (nur AP – STA wird für NTP temporär aktiviert)
   WiFi.mode(WIFI_AP);
@@ -407,28 +415,33 @@ void setup() {
     state.bonusSec = server.arg("bonus").toInt();
     state.cdEnd    = time(nullptr) + state.cdDur;
     state.phase    = State::COUNTDOWN;
+    Serial.printf("Countdown gestartet: %u s, Bonus %u s\n", state.cdDur, state.bonusSec);
     server.send(200, "text/plain", "ok");
   });
 
   server.on("/resetTimer", HTTP_GET, [](){             // Timer zurücksetzen
     state.phase = State::SHOW_CLOCK;
+    Serial.println(F("Timer zurückgesetzt"));
     server.send(200, "text/plain", "reset ok");
   });
 
   server.on("/led-post", HTTP_GET, [](){               // LED-Selbsttest starten
     if (ledTestRunning) {
+      Serial.println(F("LED-Test läuft bereits"));
       server.send(200, "text/plain", "LED-Test läuft bereits");
     } else {
       ledTestRunning    = true;
       ledTestStart      = millis();
       ledTestLastChange = ledTestStart;
       ledTestColorIndex = 0;
+      Serial.println(F("LED-Test gestartet"));
       server.send(200, "text/plain", "LED-Test gestartet");
     }
   });
 
   ElegantOTA.begin(&server);                            // OTA‑Flash via /update
   server.begin();
+  Serial.println(F("HTTP-Server gestartet"));
 }
 
 // ───────────────────────────── LOOP ────────────────────────────────
@@ -476,6 +489,7 @@ void loop() {
     case State::COUNTDOWN:
       if (now >= state.cdEnd) {
         state.phase = state.bonusSec ? State::BONUS : State::SHOW_CLOCK;
+        Serial.println(state.bonusSec ? F("Bonusphase gestartet") : F("Countdown beendet"));
       } else {
         drawCountdown(now);
         if (state.bonusSec) drawBonusBottom(now);
@@ -485,6 +499,7 @@ void loop() {
     case State::BONUS:
       if (now >= state.cdEnd + state.bonusSec) {
         state.phase = State::SHOW_CLOCK;
+        Serial.println(F("Bonusphase beendet"));
       } else {
         drawBonusTop(now);
       }

--- a/klausuhr_esp/klausuhr_esp.ino
+++ b/klausuhr_esp/klausuhr_esp.ino
@@ -33,7 +33,7 @@
 #include <FS.h>
 #include <LittleFS.h>
 #include <FastLED.h>
-#include <I2SClocklessLedDriver.h>
+#include <esp_heap_caps.h>
 #include "font7seg.h"
 #include <time.h>
 #include <esp_pm.h> // Fehlerbehebung: WLAN-Disconnection bei Aufruf von Website: Light-Sleep-Modus deaktivieren
@@ -69,7 +69,6 @@ const char*    NTP_POOL[] = { "de.pool.ntp.org", "pool.ntp.org", "time.nist.gov"
 // ─────────────────────────── LED‑Konstanten ───────────────────────────
 #define LED_TYPE    WS2812B                 // LED-Typ für FastLED
 #define COLOR_ORDER GRB
-#define ORDER_GRB 0
 #define BRIGHTNESS 48                       // Grundhelligkeit 0‑255 ≈ 20 %
 const unsigned long LED_TEST_DURATION  = 120000;  // 2 Minuten in Millisekunden
 const unsigned long LED_TEST_INTERVAL  = 1000;    // Farbwechsel alle Sekunde
@@ -101,6 +100,9 @@ constexpr uint16_t PIXELS_PER_STRIP = 40;
 int dataPins[NUM_STRIPS];
 const uint8_t PIN_BCLK = 25;
 const uint8_t PIN_WS   = 15;
+
+#define NUM_LEDS_PER_STRIP PIXELS_PER_STRIP
+#include <I2SClocklessLedDriver.h>
 
 CRGB* leds;
 CRGB* timerLeds[5];
@@ -367,7 +369,8 @@ void setup() {
 #endif
   int tmp[] = {2,4,16,17,5,18,19,21,22,23,13,12,14,27,26,0};
   memcpy(dataPins, tmp, sizeof(dataPins));
-  ledDriver.initled((uint8_t*)leds, dataPins, NUM_STRIPS, PIXELS_PER_STRIP, ORDER_GRB);
+  ledDriver.initled((uint8_t*)leds, dataPins, NUM_STRIPS, PIXELS_PER_STRIP,
+                    static_cast<colorarrangment>(ORDER_GRB));
   clearAll();
   ledDriver.showPixels();
 

--- a/klausuhr_esp/klausuhr_esp.ino
+++ b/klausuhr_esp/klausuhr_esp.ino
@@ -33,6 +33,7 @@
 #include <FS.h>
 #include <LittleFS.h>
 #include <FastLED.h>
+#include <I2SClocklessLedDriver.h>
 #include "font7seg.h"
 #include <time.h>
 #include <esp_pm.h> // Fehlerbehebung: WLAN-Disconnection bei Aufruf von Website: Light-Sleep-Modus deaktivieren
@@ -68,6 +69,7 @@ const char*    NTP_POOL[] = { "de.pool.ntp.org", "pool.ntp.org", "time.nist.gov"
 // ─────────────────────────── LED‑Konstanten ───────────────────────────
 #define LED_TYPE    WS2812B                 // LED-Typ für FastLED
 #define COLOR_ORDER GRB
+#define ORDER_GRB 0
 #define BRIGHTNESS 48                       // Grundhelligkeit 0‑255 ≈ 20 %
 const unsigned long LED_TEST_DURATION  = 120000;  // 2 Minuten in Millisekunden
 const unsigned long LED_TEST_INTERVAL  = 1000;    // Farbwechsel alle Sekunde
@@ -94,14 +96,21 @@ const uint8_t PIN_BAR_TOP = 33;                   // Ladebalken oben (40 LED)
 const uint8_t PIN_BAR_BOT = 32;                   // Ladebalken unten (39 LED)
 #endif
 
-// ────────────────────────── LED-Arrays ──────────────────────────
-CRGB timerLeds[5][NUM_TIMER_LED];
-CRGB nachLeds[5][NUM_NACH_LED];
-CRGB clockLeds[5][NUM_CLOCK_LED];
+constexpr uint8_t NUM_STRIPS = 16;
+constexpr uint16_t PIXELS_PER_STRIP = 40;
+int dataPins[NUM_STRIPS];
+const uint8_t PIN_BCLK = 25;
+const uint8_t PIN_WS   = 15;
+
+CRGB* leds;
+CRGB* timerLeds[5];
+CRGB* nachLeds[5];
+CRGB* clockLeds[5];
 #if USE_LOADING_BAR
-CRGB barTopLeds[NUM_BAR_TOP];
-CRGB barBotLeds[NUM_BAR_BOT];
+CRGB* barTopLeds;
+CRGB* barBotLeds;
 #endif
+I2SClocklessLedDriver ledDriver;
 
 // ───────────────────────── Programm‑Zustand ───────────────────────────
 struct State {
@@ -136,7 +145,7 @@ inline void clearAll() {
 
 // Zeigt alle Strips gleichzeitig an
 inline void showAll() {
-  FastLED.show();
+  ledDriver.showPixels();
 }
 
 // Füllt alle Strips mit derselben Farbe
@@ -202,35 +211,33 @@ bool syncTimeNow() {
 }
 
 // Ein Pixel unter Berücksichtigung der Strip-Richtung setzen
-template<size_t LEN>
-inline void setPixel(CRGB (&strip)[LEN], uint16_t pos, bool reversed,
+inline void setPixel(CRGB* strip, uint16_t len, uint16_t pos, bool reversed,
                      uint8_t r, uint8_t g, uint8_t b) {
-  uint16_t idx = reversed ? LEN - 1 - pos : pos;
-  if (idx < LEN) strip[idx] = CRGB(r, g, b);
+  uint16_t idx = reversed ? len - 1 - pos : pos;
+  if (idx < len) strip[idx] = CRGB(r, g, b);
 }
 
 // Zeichnet ein 3x5-Digit an gegebener Startspalte
-template<size_t LEN>
-inline void drawDigit(CRGB (&strips)[5][LEN], uint16_t start, bool reversed,
-                      uint8_t digit, uint8_t r, uint8_t g, uint8_t b) {
+inline void drawDigit(CRGB* strips[5], uint16_t start, bool reversed,
+                      uint8_t digit, uint8_t r, uint8_t g, uint8_t b,
+                      uint16_t len) {
   for (uint8_t row = 0; row < 5; ++row) {
     uint8_t bits = pgm_read_byte(&FONT_3x5[digit][row]);
     for (uint8_t col = 0; col < 3; ++col) {
       bool on = bits & (1 << (2 - col));
-      setPixel(strips[row], start + col, reversed,
+      setPixel(strips[row], len, start + col, reversed,
                on ? r : 0, on ? g : 0, on ? b : 0);
     }
   }
 }
 
 // Doppelpunkt zeichnen (Punkte in Zeile 2 und 4)
-template<size_t LEN>
-inline void drawColon(CRGB (&strips)[5][LEN], uint16_t col, bool reversed,
-                      uint8_t r, uint8_t g, uint8_t b) {
+inline void drawColon(CRGB* strips[5], uint16_t col, bool reversed,
+                      uint8_t r, uint8_t g, uint8_t b, uint16_t len) {
   const bool dots[5] = {false, true, false, true, false};
   for (uint8_t row = 0; row < 5; ++row) {
-    if (dots[row]) setPixel(strips[row], col, reversed, r, g, b);
-    else           setPixel(strips[row], col, reversed, 0, 0, 0);
+    if (dots[row]) setPixel(strips[row], len, col, reversed, r, g, b);
+    else           setPixel(strips[row], len, col, reversed, 0, 0, 0);
   }
 }
 
@@ -249,11 +256,11 @@ void drawClock() {
   struct tm t {}; time_t now = time(nullptr); localtime_r(&now, &t);
   uint8_t h = t.tm_hour, m = t.tm_min;
   // Stunden in Cyan, Minuten in Weiß
-  drawDigit(clockLeds, 0,  false, h / 10, 0, 255, 255);
-  drawDigit(clockLeds, 4,  false, h % 10, 0, 255, 255);
-  drawColon(clockLeds, 8,  false, 255, 255, 255);
-  drawDigit(clockLeds, 10, false, m / 10, 255, 255, 255);
-  drawDigit(clockLeds, 14, false, m % 10, 255, 255, 255);
+  drawDigit(clockLeds, 0,  false, h / 10, 0, 255, 255, NUM_CLOCK_LED);
+  drawDigit(clockLeds, 4,  false, h % 10, 0, 255, 255, NUM_CLOCK_LED);
+  drawColon(clockLeds, 8,  false, 255, 255, 255, NUM_CLOCK_LED);
+  drawDigit(clockLeds, 10, false, m / 10, 255, 255, 255, NUM_CLOCK_LED);
+  drawDigit(clockLeds, 14, false, m % 10, 255, 255, 255, NUM_CLOCK_LED);
   showAll();
 }
 
@@ -276,12 +283,12 @@ void drawCountdown(time_t now) {
   uint8_t r = warn ? 255 : 255;
   uint8_t g = warn ? 0   : 255;
   uint8_t b = warn ? 0   : 255;
-  drawDigit(timerLeds, 0,  false, (totalMin / 100) % 10, r, g, b);
-  drawDigit(timerLeds, 4,  false, (totalMin / 10) % 10, r, g, b);
-  drawDigit(timerLeds, 8,  false, totalMin % 10, r, g, b);
-  drawColon(timerLeds, 12, false, r, g, b);
-  drawDigit(timerLeds, 14, false, s / 10, r, g, b);
-  drawDigit(timerLeds, 18, false, s % 10, r, g, b);
+  drawDigit(timerLeds, 0,  false, (totalMin / 100) % 10, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 4,  false, (totalMin / 10) % 10, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 8,  false, totalMin % 10, r, g, b, NUM_TIMER_LED);
+  drawColon(timerLeds, 12, false, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 14, false, s / 10, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 18, false, s % 10, r, g, b, NUM_TIMER_LED);
 
 #if USE_LOADING_BAR
   auto drawBar = [](CRGB* bar, uint16_t count, float prog) {
@@ -306,12 +313,12 @@ void drawBonusTop(time_t now) {
   if (rem < 0) rem = 0;
   uint16_t m = rem / 60;
   uint8_t r = 128, g = 0, b = 128;            // Lila
-  drawDigit(timerLeds, 0,  false, (m / 100) % 10, r, g, b);
-  drawDigit(timerLeds, 4,  false, (m / 10) % 10, r, g, b);
-  drawDigit(timerLeds, 8,  false, m % 10, r, g, b);
-  drawColon(timerLeds, 12, false, 0, 0, 0);
-  drawDigit(timerLeds, 14, false, 0, 0, 0, 0);
-  drawDigit(timerLeds, 18, false, 0, 0, 0, 0);
+  drawDigit(timerLeds, 0,  false, (m / 100) % 10, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 4,  false, (m / 10) % 10, r, g, b, NUM_TIMER_LED);
+  drawDigit(timerLeds, 8,  false, m % 10, r, g, b, NUM_TIMER_LED);
+  drawColon(timerLeds, 12, false, 0, 0, 0, NUM_TIMER_LED);
+  drawDigit(timerLeds, 14, false, 0, 0, 0, 0, NUM_TIMER_LED);
+  drawDigit(timerLeds, 18, false, 0, 0, 0, 0, NUM_TIMER_LED);
   float progress = 1.0f - rem / (float)state.bonusSec;
 #if USE_LOADING_BAR
   int fillTop = round(progress * NUM_BAR_TOP);
@@ -333,9 +340,9 @@ void drawBonusBottom(time_t now) {
   if (rem < 0) rem = 0;
   uint16_t m = rem / 60;
   uint8_t r = 128, g = 0, b = 128;
-  drawDigit(nachLeds, 0, true, (m / 100) % 10, r, g, b);
-  drawDigit(nachLeds, 4, true, (m / 10) % 10, r, g, b);
-  drawDigit(nachLeds, 8, true, m % 10, r, g, b);
+  drawDigit(nachLeds, 0, true, (m / 100) % 10, r, g, b, NUM_NACH_LED);
+  drawDigit(nachLeds, 4, true, (m / 10) % 10, r, g, b, NUM_NACH_LED);
+  drawDigit(nachLeds, 8, true, m % 10, r, g, b, NUM_NACH_LED);
   showAll();
 }
 
@@ -349,18 +356,20 @@ void setup() {
   esp_pm_lock_acquire(pm_lock_l0);
   
   // 2) LED‑Streifen initialisieren
-  FastLED.setBrightness(BRIGHTNESS);
-  for (int i = 0; i < 5; ++i) {
-    FastLED.addLeds<LED_TYPE, COLOR_ORDER>(timerLeds[i], NUM_TIMER_LED).setPin(PIN_T[i]);
-    FastLED.addLeds<LED_TYPE, COLOR_ORDER>(nachLeds[i],  NUM_NACH_LED).setPin(PIN_N[i]);
-    FastLED.addLeds<LED_TYPE, COLOR_ORDER>(clockLeds[i], NUM_CLOCK_LED).setPin(PIN_C[i]);
-  }
+  leds = (CRGB*)heap_caps_malloc(NUM_STRIPS * PIXELS_PER_STRIP * sizeof(CRGB), MALLOC_CAP_DMA);
+  int idx = 0;
+  for (int i = 0; i < 5; ++i) { timerLeds[i] = &leds[idx]; idx += PIXELS_PER_STRIP; }
+  for (int i = 0; i < 5; ++i) { nachLeds[i]  = &leds[idx]; idx += PIXELS_PER_STRIP; }
+  for (int i = 0; i < 5; ++i) { clockLeds[i] = &leds[idx]; idx += PIXELS_PER_STRIP; }
 #if USE_LOADING_BAR
-  FastLED.addLeds<LED_TYPE, COLOR_ORDER>(barTopLeds, NUM_BAR_TOP).setPin(PIN_BAR_TOP);
-  FastLED.addLeds<LED_TYPE, COLOR_ORDER>(barBotLeds, NUM_BAR_BOT).setPin(PIN_BAR_BOT);
+  barTopLeds = &leds[idx]; idx += PIXELS_PER_STRIP;
+  barBotLeds = &leds[idx]; idx += PIXELS_PER_STRIP;
 #endif
+  int tmp[] = {2,4,16,17,5,18,19,21,22,23,13,12,14,27,26,0};
+  memcpy(dataPins, tmp, sizeof(dataPins));
+  ledDriver.initled((uint8_t*)leds, dataPins, NUM_STRIPS, PIXELS_PER_STRIP, ORDER_GRB);
   clearAll();
-  FastLED.show();
+  ledDriver.showPixels();
 
   // 3) LittleFS einbinden (Web‑Dateien)
   if (!LittleFS.begin(true)) {


### PR DESCRIPTION
## Summary
- add I2SClocklessLedDriver support
- allocate DMA buffers in internal RAM
- initialize driver with data pin array
- replace FastLED.show() calls
- fix compile errors with new driver functions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684995416ed4832ab0ce8599ae78d52c