### PR TITLE
Fix LED state after NTP sync

### DIFF
--- a/klausuhr_esp/klausuhr_esp.ino
+++ b/klausuhr_esp/klausuhr_esp.ino
@@ -198,6 +198,9 @@ bool syncTimeNow() {
     struct tm tinfo {};
     if (getLocalTime(&tinfo, 10000)) {
       Serial.println(F("NTP Sync erfolgreich"));
+      clearAll();                 // LEDs dunkel halten
+      showAll();
+      state.phase = State::SHOW_CLOCK; // Uhrzeitanzeige aktivieren
       ok = true;
     } else {
       Serial.println(F("NTP Sync fehlgeschlagen"));


### PR DESCRIPTION
## Summary
- keep all strips off once the initial time sync succeeds
- ensure clock view is enabled immediately after successful NTP sync

## Testing
- `platformio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abb7d4ad0832a8ff4a7bc7390df23